### PR TITLE
FIX: Removed -it flag and added -e for env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ docker build -t gong-mcp .
   "command": "docker",
   "args": [
     "run",
-    "-it",
+    "-i",
     "--rm",
+    "-e", "GONG_ACCESS_KEY",
+    "-e", "GONG_ACCESS_SECRET",
     "gong-mcp"
   ],
   "env": {


### PR DESCRIPTION
With the current example for adding the mcp server to Claude Desktop, the MCP server will crash. The crash is due to `-it` and how the MCP server is expecting a proper JSON-RPC formatted response. 

With `-it`:
```
{"jsonrpc":"2.0","id":0,"method":"initialize",...}
```

With just `-i`:
```
{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"gong","version":"0.1.0"}}}
```

Additionally, I added in the `-e` flag ensure the environment variables set are correctly passed in. 