### PR TITLE
Update Docker image and instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Environment files (secrets should be passed at runtime)
+.env
+.env.*
+!.env.example
+
+# Git
+.git
+.gitignore
+
+# Dependencies (will be installed in container)
+node_modules
+
+# Build output (will be built in container)
+dist
+
+# Documentation
+README.md
+CLAUDE.md
+
+# IDE and editor files
+.idea
+.vscode
+*.swp
+*.swo
+.DS_Store
+
+# Logs
+logs
+*.log
+
+# Test and coverage
+coverage
+
+# AI assistants
+CLAUDE.md
+.claude

--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,8 @@ coverage/
 
 # Temporary files
 tmp/
-temp/ 
+temp/
+
+# AI assistants
+CLAUDE.md
+.claude

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,13 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm install 2>&1
+RUN npm install
 
 # Copy source code
 COPY . .
 
 # Build TypeScript code
-RUN npm run build 2>&1
+RUN npm run build
 
 # Start the server
-CMD ["sh", "-c", "node dist/index.js 2>&1"] 
+CMD ["node", "dist/index.js"] 

--- a/README.md
+++ b/README.md
@@ -29,36 +29,103 @@ A Model Context Protocol (MCP) server that provides access to Gong's API for ret
    npm run build
    ```
 
+4. Copy `.env.example` to `.env`:
+   ```bash
+   cp .env.example .env
+   ```
+
+5. Edit `.env` and replace the values in the configuration file with your Gong credentials.
+
+THe `.env` file is ignored in the `.gitignore` and `.dockerignore` files so it won't be accidentally shared.
+
 ### Docker
 
 Build the container:
+
 ```bash
 docker build -t gong-mcp .
 ```
 
-## Configuring Claude
+You can also use `npm run docker:build` as a shortcut.
 
-1. Open Claude Desktop settings
-2. Navigate to the MCP Servers section
-3. Add a new server with the following configuration:
+Test the container image using environment file (recommended):
+
+```bash
+docker run -i --rm --env-file .env gong-mcp
+```
+
+Or test with individual environment variables:
+
+```bash
+docker run -i --rm  \
+  -e GONG_ACCESS_KEY="your_access_key_here" \
+  -e GONG_ACCESS_SECRET="your_access_secret_here" \
+  gong-mcp
+```
+
+Press `CTRL-C` to stop the container.
+
+
+## Configuring Claude Desktop
+
+1. Open Claude Desktop settings and go to the **Developer** tab.
+1. Press **Edit Config**.
+1. Open the `claude_desktop_config.json` file in your editor.
+1. Navigate to the `mcpServers` section or add it if it doesn't exist.
+1. Add a new server with one of the following configurations:
+
+### Option 1: Using Environment File (Recommended)
+
+This keeps credentials out of the Claude Desktop config file:
 
 ```json
 {
-  "command": "docker",
-  "args": [
-    "run",
-    "-it",
-    "--rm",
-    "gong-mcp"
-  ],
-  "env": {
-    "GONG_ACCESS_KEY": "your_access_key_here",
-    "GONG_ACCESS_SECRET": "your_access_secret_here"
+  "mcpServers": {
+    "gong": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "--env-file",
+        "/absolute/path/to/gong-mcp/.env",
+        "gong-mcp"
+      ]
+    }
   }
 }
 ```
 
-4. Replace the placeholder credentials with your actual Gong API credentials from your `.env` file
+Replace `/absolute/path/to/gong-mcp/.env` with the actual absolute path to your
+`.env` file. Specify the entire path; you won't be able to use `~/` in the configuration.
+
+### Option 2: Using Inline Environment Variables
+
+This embeds credentials directly in the config file (not ideal:)
+
+```json
+{
+  "mcpServers": {
+    "gong": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e", "GONG_ACCESS_KEY=your_access_key_here",
+        "-e", "GONG_ACCESS_SECRET=your_access_secret_here",
+        "gong-mcp"
+      ]
+    }
+  }
+}
+```
+
+Replace `your_access_key_here` and `your_access_secret_here` with your actual Gong API credentials.
+
+---
+
+After configuring, save the file and restart Claude Desktop. You can then ask Claude to list Gong calls and retrieve transcripts.
 
 ## Available Tools
 
@@ -118,4 +185,4 @@ MIT License - see LICENSE file for details
 2. Create your feature branch (`git checkout -b feature/amazing-feature`)
 3. Commit your changes (`git commit -m 'Add some amazing feature'`)
 4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request 
+5. Open a Pull Request

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "docker:build": "docker build -t gong-mcp ."
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.8.0",


### PR DESCRIPTION
1. No longer wrap startup command in subshell so server can run as process 1 and respond to SIGINT and SIGTERM.
2. Add .dockerignore to prevent `node_modules`, `.git`, and `.env` files from being included in the image.
3. Update instructions to use `-i` flag instead of `-it` flags as MCP servers are not TTYs.
4. Update instructions to suggest using `.env` file for Claude Desktop, and embed variables into arguments instead of using the `env` section to reduce complexity.